### PR TITLE
Fixed threaded deadlock

### DIFF
--- a/python/minisam_wrapper/optimizer.cpp
+++ b/python/minisam_wrapper/optimizer.cpp
@@ -70,11 +70,11 @@ void wrap_optimizer(py::module& m) {
             const Variables& init_values, Variables& opt_values, 
             const VariablesToEliminate& var_elimiated) {
           return opt.optimize(graph, init_values, opt_values, var_elimiated);
-        })
+        }, py::call_guard<py::gil_scoped_release>())
     .def("optimize", [](NonlinearOptimizer &opt, const FactorGraph& graph, 
             const Variables& init_values, Variables& opt_values) {
           return opt.optimize(graph, init_values, opt_values);
-        })
+        }, py::call_guard<py::gil_scoped_release>())
 
     .def("iterate", &NonlinearOptimizer::iterate)
     .def("iterations", &NonlinearOptimizer::iterations)
@@ -147,7 +147,7 @@ void wrap_optimizer(py::module& m) {
   py::class_<MarginalCovarianceSolver>(m, "MarginalCovarianceSolver")
     .def(py::init<>())
     .def(py::init<const MarginalCovarianceSolverParams&>())
-    .def("initialize", &MarginalCovarianceSolver::initialize)
+    .def("initialize", &MarginalCovarianceSolver::initialize, py::call_guard<py::gil_scoped_release>())
     .def("marginalCovariance", &MarginalCovarianceSolver::marginalCovariance)
     .def("jointMarginalCovariance", &MarginalCovarianceSolver::jointMarginalCovariance)
     ;


### PR DESCRIPTION
This fixes issue https://github.com/dongjing3309/minisam/issues/8

The problem was that when multithreading is enabled a deadlock occurs, due to multiple threads trying to acquire the GIL which is held by the main thread. By adding _py::call_guard<py::gil_scoped_release>()_ to the optimize and initialize functions it ensures that the main thread releases the GIL.

This in general should be done for any long running C++ code. 