### PR TITLE
FIxed a complie bug about fmt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ if(MINISAM_WITH_SOPHUS)
     set(MINISAM_USE_SOPHUS 1)
     get_target_property(Sophus_INCLUDE_DIR Sophus::Sophus INTERFACE_INCLUDE_DIRECTORIES)
     include_directories(AFTER ${Sophus_INCLUDE_DIR})
+    list(APPEND MINISAM_ADDITIONAL_LIBRARIES fmt)
 
   else()
     message(WARNING "Using Sophus is set, but Sophus is NOT found. Sophus will not be used")


### PR DESCRIPTION
Original CMakelists.txt hadn't include fmt library into the 'MiniSAM Additional Libraries' so that causing a link error while compiling examples and the python_package. Adding line 103 to fix the problem.